### PR TITLE
fix: double ownership transfer (`#10`)

### DIFF
--- a/src/JB721TiersHook.sol
+++ b/src/JB721TiersHook.sol
@@ -205,9 +205,6 @@ contract JB721TiersHook is JBOwnable, ERC2771Context, JB721Hook, IJB721TiersHook
         // Set the contract URI if provided.
         if (bytes(contractUri).length != 0) contractURI = contractUri;
 
-        // Transfer ownership to the initializer.
-        _transferOwnership(_msgSender());
-
         // Set the token URI resolver if provided.
         if (tokenUriResolver != IJB721TokenUriResolver(address(0))) {
             _recordSetTokenUriResolver(tokenUriResolver);

--- a/test/unit/getters_constructor_Unit.t.sol
+++ b/test/unit/getters_constructor_Unit.t.sol
@@ -430,6 +430,11 @@ contract Test_Getters_Constructor_Unit is UnitTestSetup {
         vm.assume(newOwner != address(0));
         vm.assume(previousOwner != address(0));
 
+        // Trusted forwarder is a special case, it can only be the sender if the transaction is a meta transaction.
+        // which we aren't doing here.
+        vm.assume(newOwner != trustedForwarder);
+        vm.assume(previousOwner != trustedForwarder);
+
         defaultTierConfig.allowOwnerMint = true;
         defaultTierConfig.reserveFrequency = 0;
         ForTest_JB721TiersHook hook = _initializeForTestHook(10);

--- a/test/unit/getters_constructor_Unit.t.sol
+++ b/test/unit/getters_constructor_Unit.t.sol
@@ -418,6 +418,12 @@ contract Test_Getters_Constructor_Unit is UnitTestSetup {
         assertEq(hook.firstOwnerOf(tokenId), owner);
     }
 
+    /// @notice This is a special case that was found by the fuzzer on Jango's machine, hardcoded so we can easily
+    /// replicate it.
+    function test_firstOwnerOf_shouldReturnFirstOwnerIfOwnerChanged_revertingCase() public {
+        test_firstOwnerOf_shouldReturnFirstOwnerIfOwnerChanged(address(uint160(0x625)), address(uint160(0x1E240)));
+    }
+
     function test_firstOwnerOf_shouldReturnFirstOwnerIfOwnerChanged(address newOwner, address previousOwner) public {
         // Assume that the new owner and previous owner are different and not the zero address.
         vm.assume(newOwner != previousOwner);

--- a/test/unit/getters_constructor_Unit.t.sol
+++ b/test/unit/getters_constructor_Unit.t.sol
@@ -418,12 +418,6 @@ contract Test_Getters_Constructor_Unit is UnitTestSetup {
         assertEq(hook.firstOwnerOf(tokenId), owner);
     }
 
-    /// @notice This is a special case that was found by the fuzzer on Jango's machine, hardcoded so we can easily
-    /// replicate it.
-    function test_firstOwnerOf_shouldReturnFirstOwnerIfOwnerChanged_revertingCase() public {
-        test_firstOwnerOf_shouldReturnFirstOwnerIfOwnerChanged(address(uint160(0x625)), address(uint160(0x1E240)));
-    }
-
     function test_firstOwnerOf_shouldReturnFirstOwnerIfOwnerChanged(address newOwner, address previousOwner) public {
         // Assume that the new owner and previous owner are different and not the zero address.
         vm.assume(newOwner != previousOwner);


### PR DESCRIPTION
# Description

*What does this PR: do, how, why?*

## Limitations & risks

*Are there any trade-off or new vulnarbility surface based on theses changes?*

# Check-list
- [ ] Tests are covering the new feature
- [ ] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [ ] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [ ] I have run the test locally (and they pass)
- [ ] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:

- Indirectly: